### PR TITLE
add types to amqplib, single declaration file for parser

### DIFF
--- a/packages/@noma/plugin-amqplib/package-lock.json
+++ b/packages/@noma/plugin-amqplib/package-lock.json
@@ -128,11 +128,30 @@
         }
       }
     },
+    "@types/amqplib": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.0.tgz",
+      "integrity": "sha512-RDojJ8WACs43HIfWSQGnAVwgNzjMGx4YMNeW7jptgAFgkG1EpNQqts+cND5HYWdYgTM58b+RHe675b0i4A9WpQ==",
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/bluebird": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.35.tgz",
+      "integrity": "sha512-2WeeXK7BuQo7yPI4WGOBum90SzF/f8rqlvpaXx4rjeTmNssGRDHWf7fgDUH90xMB3sUOu716fUK5d+OVx0+ncQ=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -729,8 +748,22 @@
                 "is-regex": "^1.1.1",
                 "object-inspect": "^1.9.0",
                 "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.3",
                 "string.prototype.trimstart": "^1.0.3"
+              },
+              "dependencies": {
+                "object.assign": {
+                  "version": "4.1.2",
+                  "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                  "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                  "requires": {
+                    "call-bind": "^1.0.0",
+                    "define-properties": "^1.1.3",
+                    "has-symbols": "^1.0.1",
+                    "object-keys": "^1.1.1"
+                  }
+                }
               }
             },
             "object-inspect": {

--- a/packages/@noma/plugin-amqplib/package.json
+++ b/packages/@noma/plugin-amqplib/package.json
@@ -10,7 +10,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "amqplib": "^0.6.0"
+    "amqplib": "^0.6.0",
+    "@types/amqplib": "^0.8.0"
   },
   "devDependencies": {
     "@noma/eslint-config-noma": "^1.0.0-alpha.1",

--- a/packages/@noma/plugin-amqplib/src/index.d.ts
+++ b/packages/@noma/plugin-amqplib/src/index.d.ts
@@ -1,6 +1,6 @@
 import { Connection } from "amqplib";
 
-export default interface IAmqplib {
+export default interface AmqplibNomaPluginResult {
   connection?: Connection;
   connections: {
     [key: string]: Connection;

--- a/packages/@noma/plugin-amqplib/src/index.d.ts
+++ b/packages/@noma/plugin-amqplib/src/index.d.ts
@@ -1,0 +1,8 @@
+import { Connection } from "amqplib";
+
+export default interface IAmqplib {
+  connection?: Connection;
+  connections: {
+    [key: string]: Connection;
+  };
+}


### PR DESCRIPTION
Contains minimal changes to get amqplib going with the new typescript parser

**Possible discussion:** 
Do you mind having source files as Typescript files (.ts) instead of .js ones, and transpile to .js only when we publish on npm?